### PR TITLE
handle jQuery matches with multiple elements

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -67,7 +67,7 @@
 */
 (function($) {
     $.fn.menuAim = function(opts) {
-
+     var action = function(){
         var $menu = $(this),
             activeRow = null,
             mouseLocs = [],
@@ -259,7 +259,8 @@
         };
 
         init();
-        return this;
+     }; /* end action function definition */    
+     return this.each(action);
     };
 })(jQuery);
 


### PR DESCRIPTION
A jQuery match operation may return more than one element.
Your code does not take this into account. This is a minimal patch to fix
the problem ($menu only being evaluated on the first element of the match).
Obviously the fix could be made much 'nicer' but more lines of code would change.

The reason I like to see this fixed, is because I use aim in a structure where
multiple menus are affected by it services.
