### PR TITLE
Improve performance by changing binding of mousemoveDocument to $menu

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -253,9 +253,8 @@
                 .mouseleave(mouseleaveMenu)
                 .find(options.rowSelector)
                     .mouseenter(mouseenterRow)
-                    .mouseleave(mouseleaveRow);
-
-            $(document).mousemove(mousemoveDocument);
+                    .mouseleave(mouseleaveRow)
+                    .mousemove(mousemoveDocument);
         };
 
         init();


### PR DESCRIPTION
Was  `$(document).mousemove(mousemoveDocument);`
Which means that _every_ mouse-move on the document would of trigger this callback...
which would be very un-efficient (especially on medium to large pages with lots of DOM elements..

So I suggest changing it to:  `$menu.mousemove(mousemoveDocument);` (I tried and it still works!) 

Perhaps add the binding of `mousemoveDocument` as an `option` where the user can define a selector..
