### PR TITLE
Remove active row when exiting menu.

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -104,6 +104,7 @@
                 if (timeoutId) {
                     clearTimeout(timeoutId);
                 }
+                activeRow = null;
             };
 
         /**


### PR DESCRIPTION
Currently leaving, collapsing, then re-opening keeps the previously active row highlighted.
![Screen Shot 2013-03-22 at 11 34 19 AM](https://f.cloud.github.com/assets/1056138/291469/fdde365c-9305-11e2-96fc-8ffb9f47b1d8.png)
