### PR TITLE
Should clear any pending activation when leaving an element

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -144,6 +144,10 @@
                 possiblyActivate(this);
             },
             mouseleaveRow = function() {
+                if (timeoutId) {
+                    // Cancel any pending activation
+                    clearTimeout(timeoutId);
+                }
                 options.exit(this);
             };
 


### PR DESCRIPTION
Not clearing the timeout will result in delayed unwanted activation when you have a menu with "blank" areas, meaning where no other activation occurs, but you are still inside the menu container with the mouse pointer.
