### PR TITLE
Resetting activeRow when going to a non submenuSelector element

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -166,6 +166,11 @@
                     options.deactivate(activeRow);
                 }
 
+                if (! $(row).is(options.submenuSelector)){
+                    activeRow = null;
+                    return;
+                }
+                
                 options.activate(row);
                 activeRow = row;
             };


### PR DESCRIPTION
I notice that when I hover an non activable element the "activeRow" wasn't resetted.
