### PR TITLE
Added bower.json to make this plugin installable with bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,12 @@
+{
+  "name": "jquery.menu-aim",
+  "version": "1.0.0",
+  "main": "jquery.menu-aim.js",
+  "dependencies": {
+    "jquery": "*"
+  },
+  "ignore": [
+    "example",
+    "*.png"
+  ]
+}


### PR DESCRIPTION
This will only work if you create a tag afterwards:

```
git tag -a 1.0.0 -m "Version 1.0.0"
git push --tags
```

**Installing plugin with bower:**

```
bower install jquery.menu-aim
```
