### PR TITLE
Calling exitMenu callback

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -120,15 +120,13 @@
                     clearTimeout(timeoutId);
                 }
 
-                // If exitMenu is supplied and returns true, deactivate the
-                // currently active row on menu exit.
-                if (options.exitMenu(this)) {
-                    if (activeRow) {
-                        options.deactivate(activeRow);
-                    }
-
-                    activeRow = null;
+                options.exitMenu(this);
+                // Deactivate the currently active row on menu exit.
+                if (activeRow) {
+                    options.deactivate(activeRow);
                 }
+
+                activeRow = null;
             };
 
         /**


### PR DESCRIPTION
Remove the need to return true/false in exitMenu callback.
