### PR TITLE
Asynchronous Module Definition (AMD) support

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -69,8 +69,16 @@
  *
  * https://github.com/kamens/jQuery-menu-aim
 */
-(function($) {
-
+// Uses Asynchronous Module Definition (AMD) or browser globals to create a jQuery plugin.
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+} (function ($) {
     $.fn.menuAim = function(opts) {
         // Initialize menu-aim for all elements in jQuery collection
         this.each(function() {
@@ -319,5 +327,5 @@
         $(document).mousemove(mousemoveDocument);
 
     };
-})(jQuery);
+}));
 


### PR DESCRIPTION
jQuery supports the AMD API by wrapping itself in a define() method and declaring itself as named AMD module.
