### PR TITLE
Handle dynamic menu changes

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -310,11 +310,10 @@
          * Hook up initial menu events
          */
         $menu
-            .mouseleave(mouseleaveMenu)
-            .find(options.rowSelector)
-                .mouseenter(mouseenterRow)
-                .mouseleave(mouseleaveRow)
-                .click(clickRow);
+            .on("mouseleave", mouseleaveMenu)
+            .on("mouseenter", options.rowSelector, mouseenterRow)
+            .on("mouseleave", options.rowSelector, mouseleaveRow)
+            .on("click", options.rowSelector, clickRow);
 
         $(document).mousemove(mousemoveDocument);
 


### PR DESCRIPTION
Handle the case where the menu changes dynamically after the initialization. I.e. menu items are added or removed.

Moreover, this should have slightly better performance since there is only one event listener for all rows, instead of a separate event listener for each row. 

Fixes same as #31  
