### PR TITLE
Fix bug when entering the first row not activated after leaving #14

### DIFF
--- a/jquery.menu-aim.js
+++ b/jquery.menu-aim.js
@@ -142,6 +142,7 @@
 
                 options.enter(this);
                 possiblyActivate(this);
+                options.activate(activeRow);
             },
             mouseleaveRow = function() {
                 options.exit(this);


### PR DESCRIPTION
This fixes the issue #14.
It automatically enables the first row to be activated when entering the menu. 